### PR TITLE
fix navx resetting

### DIFF
--- a/src/main/java/com/team2502/robot2019/Robot.java
+++ b/src/main/java/com/team2502/robot2019/Robot.java
@@ -94,8 +94,6 @@ public class Robot extends TimedRobot
 
         SCORING_HUD = new ScoringHUD();
         AutoSwitcher.putToSmartDashboard();
-
-        NAVX.reset();
     }
 
 
@@ -129,6 +127,7 @@ public class Robot extends TimedRobot
     @Override
     public void autonomousInit()
     {
+        NAVX.reset();
 
         CommandCreator command = new CommandCreator(new VoltageDriveAction(0.2, 0.2, 3), Robot.ACTION_SCHEDULER);
 

--- a/src/main/java/com/team2502/robot2019/command/vision/GoToTargetStupidAction.java
+++ b/src/main/java/com/team2502/robot2019/command/vision/GoToTargetStupidAction.java
@@ -1,0 +1,4 @@
+package com.team2502.robot2019.command.vision;
+
+public class GoToTargetStupidAction {
+}


### PR DESCRIPTION
the navX should be reset at the beginning of autonomous, since the
heading of the robot can change between when the robot is initialized
and when autonomous starts. We had issues resetting this in the wrong
place last year.